### PR TITLE
Fix student editing modal

### DIFF
--- a/src/main/java/com/proyecto/springBoot/controller/EstudianteController.java
+++ b/src/main/java/com/proyecto/springBoot/controller/EstudianteController.java
@@ -152,7 +152,7 @@ public class EstudianteController {
     @PostMapping("/admin/estudiantes/editar")
     public String editarEstudiante(@ModelAttribute("estudianteEditar") Estudiante estudiante, Model model, Authentication auth) {
         try {
-            servicio.save(estudiante);
+            servicio.update(estudiante);
         } catch (IllegalArgumentException ex) {
             String errorMsg = ex.getMessage();
             if (errorMsg.contains("cédula")) {

--- a/src/main/java/com/proyecto/springBoot/service/EstudianteService.java
+++ b/src/main/java/com/proyecto/springBoot/service/EstudianteService.java
@@ -28,6 +28,15 @@ public class EstudianteService {
         return repository.save(estudiante);
     }
 
+    /**
+     * Updates an existing student without validating uniqueness of the cédula.
+     * Used when editing a record.
+     */
+    public Estudiante update(Estudiante estudiante) {
+        Validador.validarEstudiante(estudiante);
+        return repository.save(estudiante);
+    }
+
     public void deleteById(String cedula){
         repository.deleteById(cedula);
     }


### PR DESCRIPTION
## Summary
- allow updates without uniqueness check in `EstudianteService`
- call the new update method from `EstudianteController`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859abb891c88323af87d8379ba122a5